### PR TITLE
Fix a bug that AngularEmitter fails if Router isn't present

### DIFF
--- a/src/AngularEmitter.js
+++ b/src/AngularEmitter.js
@@ -177,7 +177,7 @@ const AngularEmitter = function (options = { rootSelector: 'app-root' }) {
         console.error(error); return;
       }
       const rootInstance = api(rootElement);
-      const Router = rootInstance.injector.get(window['ng'].coreTokens.Router);
+      const Router = window['ng'].coreTokens.Router && rootInstance.injector.get(window['ng'].coreTokens.Router);
 
       sendMessage({
         type: '@@angular_rootDetected',


### PR DESCRIPTION
Faced this bug in the Angular app. I realize that Angular apps without Router are rare, but.